### PR TITLE
Telegraf slice issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   telegraf:
-    image: telegraf:1.16
+    image: telegraf:1.22
     container_name: telegraf
     restart: always
     volumes:
@@ -19,7 +19,7 @@ services:
       - tick
 
   influxdb:
-    image: influxdb:1.8
+    image: influxdb:1.8.10
     container_name: influxdb
     restart: always
     volumes:
@@ -30,7 +30,7 @@ services:
       - tick
 
   chronograf:
-    image: chronograf:1.8
+    image: chronograf:1.9.4
     container_name: chronograf
     restart: always
     environment:

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -98,6 +98,14 @@
 #   ##   To use TCP, set endpoint = "tcp://[ip]:[port]"
 #   ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
     endpoint = "unix:///var/run/docker.sock"
+    container_names = []
+    container_name_include = []
+    container_name_exclude = []
+    timeout = "5s"
+    perdevice = true
+    docker_label_include = []
+    docker_label_exclude = []
+
 
 # Read metrics about cpu usage
 [[inputs.cpu]]


### PR DESCRIPTION
I ran into this issue noted here: https://github.com/influxdata/telegraf/issues/2385#issue-206463976 when attempting to use this repo on a:

```
PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
NAME="Raspbian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```

This PR updates the containers in the docker-compose.yml file with the latest versions that mitigates this issue on a arm/v7 architecture. 

There is one catch that I ran into. Telegraf showed a permission denied for the docker.sock which was corrected by: https://github.com/influxdata/telegraf/issues/10050#issuecomment-1004411264

